### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "deno"
+run = "deno run --allow-env --allow-net --allow-write --allow-read --allow-plugin --unstable ./src/server.ts"

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 ### **Install deno from 'https://deno.land/#installation'**
-
+[![Run on Repl.it](https://repl.it/badge/github/quenginedev/strono)](https://repl.it/github/quenginedev/strono)
 inside the directory of the project, run:
 `deno run --allow-env --allow-net --allow-write --allow-read --allow-plugin --unstable ./src/server.ts`
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).